### PR TITLE
Add more barrier types to bicycle profile whitelist

### DIFF
--- a/bike.lua
+++ b/bike.lua
@@ -49,8 +49,13 @@ function setup()
       'sally_port',
       'gate',
       'lift_gate',
+      'swing_gate',
+      'sliding_gate',
+      'hampshire_gate',
       'no',
-      'block'
+      'block',
+      'kerb',
+      'height_restrictor'
     },
 
     access_tag_whitelist = Set {


### PR DESCRIPTION
Allow bicycle routing over kerbs (+ some other barrier types that should be passable on a bike)