### PR TITLE
Don't route on proposed ways

### DIFF
--- a/bike.lua
+++ b/bike.lua
@@ -210,7 +210,8 @@ function setup()
 
     avoid = Set {
       'impassable',
-      'construction'
+      'construction',
+      'proposed'
     },
 
 

--- a/foot.lua
+++ b/foot.lua
@@ -98,7 +98,8 @@ function setup()
     },
 
     avoid = Set {
-      'impassable'
+      'impassable',
+      'proposed'
     },
 
     speeds = Sequence {


### PR DESCRIPTION
Routing on proposed ways was blacklisted only for car profile. This adds the same blacklisting also for foot and bike profiles.

It looks like this behavior was added in https://github.com/Project-OSRM/osrm-backend/pull/4258 and then accidentally reverted when pull request at https://github.com/Project-OSRM/osrm-backend/pull/4072 was merged. This commit restores the original change for bike and foot profiles.

There is also an open pull request on the upstream osrm-backend repository: https://github.com/Project-OSRM/osrm-backend/pull/6615

It includes automated tests for these cases and references a GitHub issue that has more background information.